### PR TITLE
Fix issue with reduce no longer performing magic

### DIFF
--- a/lib/FunctionalParsers.rakumod
+++ b/lib/FunctionalParsers.rakumod
@@ -268,7 +268,9 @@ sub chain-left(&p, &sep) is export(:MANDATORY, :ALL) {
 
 # Chain right
 sub chain-right(&p, &sep) is export(:MANDATORY, :ALL) {
-    apply( { reduce( { $^b[1]($^b[0], $^a) }, $_[1], |$_[0].reverse) }, sequence(many(sequence(&p, &sep)), &p))
+    apply( { reduce( -> $a, $b? {
+        $b.defined ?? $b[1]($b[0], $a) !! $a
+    }, $_[1], |$_[0].reverse) }, sequence(many(sequence(&p, &sep)), &p))
 }
 
 #============================================================


### PR DESCRIPTION
The "operator" of a &reduce must be able to accept 1 and 0 arg cases as well.  The block in chain-right wasn't able to do that, and started failing in tests since

  https://github.com/rakudo/rakudo/commit/9bcb01e966d2b29c103faa32ba880e2ab444648c

which showed up in https://github.com/rakudo/rakudo/issues/5783